### PR TITLE
fix: handle default option when building OpenAPI schema

### DIFF
--- a/lib/open_api/open_api.ex
+++ b/lib/open_api/open_api.ex
@@ -96,6 +96,10 @@ defmodule EctoCommand.OpenApi do
     end)
   end
 
+  def schema_for({:default, value}, acc) do
+    Map.put(acc, :default, value)
+  end
+
   def schema_for({:doc, options}, acc) do
     Map.merge(acc, Enum.into(options, %{}))
   end

--- a/test/unit/command/open_api/open_api_test.exs
+++ b/test/unit/command/open_api/open_api_test.exs
@@ -27,7 +27,7 @@ defmodule Unit.EctoCommand.OpenApi.OpenApiTest do
       param :an_integer_b, :integer, number: [not_equal_to: 20]
       param :an_integer_c, :integer, number: [greater_than: 18, less_than_or_equal_to: 100]
       param :type_id, :string
-      param :accepts, :boolean, doc: Type.boolean()
+      param :accepts, :boolean, default: false, doc: Type.boolean()
       param :folder_id, :string, change: &String.valid?/1
       param :uploaded_at, :utc_datetime, doc: Type.datetime()
 
@@ -38,7 +38,7 @@ defmodule Unit.EctoCommand.OpenApi.OpenApiTest do
 
   test "all properties docs are generated correctly" do
     assert %{
-             accepts: %OpenApiSpex.Schema{example: true, type: :boolean},
+             accepts: %OpenApiSpex.Schema{example: true, type: :boolean, default: false},
              an_integer_a: %OpenApiSpex.Schema{
                exclusiveMaximum: false,
                exclusiveMinimum: false,


### PR DESCRIPTION
Something like this works correctly, under the hood ecto embedded_schema is build and validated properly:

```elixir
defmodule Sample do
    @moduledoc false

    use EctoCommand
    use EctoCommand.OpenApi, title: "Sample"
    
    command do
      param :name, :string, default: "some default"
    end
end
```

but if I try to use `Sample.schema()` invocation fails with:

```
 ** (FunctionClauseError) no function clause matching in EctoCommand.OpenApi.schema_for/2

     The following arguments were given to EctoCommand.OpenApi.schema_for/2:

         # 1
         {:default, true}

         # 2
         %{type: :boolean}

     Attempted function clauses (showing 7 out of 7):

         def schema_for({:change, _options}, acc)
         def schema_for({:inclusion, values}, acc)
         def schema_for({:format, format}, acc)
         def schema_for({:length, options}, acc)
         def schema_for({:number, options}, acc)
         def schema_for({:doc, options}, acc)
         def schema_for({:required, _}, acc)

     code: assert {:ok, []} = ExampleQuery.schema()
```

I added the handling of `default` option in Open API schema generation