### PR TITLE
feat: allow to hide fields from documentation

### DIFF
--- a/lib/open_api/open_api.ex
+++ b/lib/open_api/open_api.ex
@@ -22,7 +22,7 @@ defmodule EctoCommand.OpenApi do
           Enum.reduce(@command_fields, {%{}, []}, fn field, {fields, required} ->
             {name, type, opts} = field
 
-            if opts[:internal] != true do
+            if opts[:internal] != true and opts[:doc] != false do
               required = if Enum.member?([true, []], opts[:required]), do: [name | required], else: required
               fields = Map.put(fields, name, EctoCommand.OpenApi.schema_for(type, opts))
               {fields, required}

--- a/test/unit/command/open_api/open_api_test.exs
+++ b/test/unit/command/open_api/open_api_test.exs
@@ -12,6 +12,7 @@ defmodule Unit.EctoCommand.OpenApi.OpenApiTest do
 
     command do
       param :id, :string, doc: Type.uuid()
+      param :hidden_field, :string, required: true, inclusion: ["a", "b"], doc: false
       param :numeric_id, :id
       param :name, :string, required: true, length: [min: 2, max: 255], doc: [example: "Mario"]
       param :email, :string, required: true, format: ~r/@/, length: [min: 6], doc: Type.email()
@@ -158,6 +159,8 @@ defmodule Unit.EctoCommand.OpenApi.OpenApiTest do
                example: %{a: 1}
              }
            } == Sample.schema().properties
+
+    refute Map.has_key?(Sample.schema().properties, :hidden_field)
   end
 
   test "example is generated accordingly to properties" do
@@ -188,6 +191,8 @@ defmodule Unit.EctoCommand.OpenApi.OpenApiTest do
              type_id: "string",
              uploaded_at: "2023-04-03T10:21:00Z"
            } == Sample.schema().example
+
+    refute Map.has_key?(Sample.schema().example, :hidden_field)
   end
 
   test "required fields list is generated correctly" do


### PR DESCRIPTION
I have scenarios where I need to hide some fields from public documentation,
but I have to perform validation on them, so implementing them as `internal` would be a bit messy.

I think using `doc: false` is intuitive enough and doesn't affect the library behaviour
